### PR TITLE
Credentials/Token per client instance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ plugins {
     id 'application'
     id 'maven-publish'
     id 'signing'
+    id 'groovy'
 }
 
 ext {
@@ -24,7 +25,10 @@ ext {
             conductor      : '3.5.0',
             revSpectator   : '0.122.0',
             revJersey      : '1.19.4',
-            revEurekaClient: '1.10.10'
+            revEurekaClient: '1.10.10',
+            spock          : '2.1-groovy-2.5',
+            awaitility     : '3.1.6',
+            wiremock       : '2.33.2'
     ]
 }
 
@@ -46,6 +50,12 @@ dependencies {
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+
+    testImplementation 'org.codehaus.groovy:groovy'
+    testImplementation 'org.codehaus.groovy:groovy-json'
+    testImplementation "org.spockframework:spock-core:${versions.spock}"
+    testImplementation "org.awaitility:awaitility-groovy:${versions.awaitility}"
+    testImplementation "com.github.tomakehurst:wiremock-jre8:${versions.wiremock}"
 }
 
 dependencyManagement {

--- a/src/main/java/io/orkes/conductor/client/http/auth/AuthorizationClientFilter.java
+++ b/src/main/java/io/orkes/conductor/client/http/auth/AuthorizationClientFilter.java
@@ -33,12 +33,14 @@ public class AuthorizationClientFilter extends ClientFilter {
     private final ObjectMapper objectMapper;
     private final String keyId;
     private final String secret;
+    private final TokenHolder tokenHolder;
 
     public AuthorizationClientFilter(String rootUri, String keyId, String secret) {
         this.rootUri = Objects.requireNonNull(rootUri).replaceAll("/$", "");
         this.keyId = Objects.requireNonNull(keyId);
         this.secret = Objects.requireNonNull(secret);
         this.objectMapper = new ObjectMapperProvider().getObjectMapper();
+        this.tokenHolder = new TokenHolder();
         this.client = initClient();
     }
 
@@ -72,13 +74,13 @@ public class AuthorizationClientFilter extends ClientFilter {
     }
 
     private String getToken() {
-        String token = TokenHolder.getToken();
+        String token = tokenHolder.getToken();
         if (token == null) {
             synchronized (LOCK) {
-                token = TokenHolder.getToken();
+                token = tokenHolder.getToken();
                 if (token == null) {
                     token = postForToken();
-                    TokenHolder.setToken(token);
+                    tokenHolder.setToken(token);
                 }
             }
         }

--- a/src/main/java/io/orkes/conductor/client/http/auth/TokenHolder.java
+++ b/src/main/java/io/orkes/conductor/client/http/auth/TokenHolder.java
@@ -1,13 +1,13 @@
 package io.orkes.conductor.client.http.auth;
 
 public class TokenHolder {
-    private static volatile String TOKEN;
+    private volatile String token;
 
-    public static void setToken(String token) {
-        TOKEN = token;
+    public void setToken(String token) {
+        this.token = token;
     }
 
-    public static String getToken() {
-        return TOKEN;
+    public String getToken() {
+        return token;
     }
 }

--- a/src/test/groovy/io/orkes/conductor/client/AbstractIT.groovy
+++ b/src/test/groovy/io/orkes/conductor/client/AbstractIT.groovy
@@ -1,0 +1,42 @@
+package io.orkes.conductor.client
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import groovy.json.JsonBuilder
+import spock.lang.Shared
+import spock.lang.Specification
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
+
+abstract class AbstractIT extends Specification {
+
+    def @Shared
+            wireMockServer = new WireMockServer(wireMockConfig().dynamicPort())
+
+    void setupSpec() {
+        wireMockServer.start()
+
+    }
+
+    void setup() {
+        WireMock.configureFor(port)
+    }
+
+    void cleanup() {
+        WireMock.reset()
+    }
+
+    void cleanupSpec() {
+        wireMockServer.stop()
+    }
+
+    int getPort() {
+        wireMockServer.port()
+    }
+
+    static String json(Map map) {
+        def json = new JsonBuilder()
+        json map
+        json.toString()
+    }
+}

--- a/src/test/groovy/io/orkes/conductor/client/http/auth/AuthorizationClientFilterIT.groovy
+++ b/src/test/groovy/io/orkes/conductor/client/http/auth/AuthorizationClientFilterIT.groovy
@@ -1,0 +1,96 @@
+package io.orkes.conductor.client.http.auth
+
+import io.orkes.conductor.client.AbstractIT
+import io.orkes.conductor.client.http.OrkesMetadataClient
+
+import java.util.concurrent.CountDownLatch
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*
+import static java.util.concurrent.TimeUnit.SECONDS
+import static org.awaitility.Awaitility.await
+
+class AuthorizationClientFilterIT extends AbstractIT {
+
+    def keyId = "80caf922-cf9c-4034-ba95-2a9ef526c4bc"
+    def secret = "DaS3Cr3T"
+
+    def "it shouldn't generate a token before a request if credentials are not set"() {
+        given:
+            // We use OrkesMetadataClient because it uses AuthorizationClientFilter as all other clients
+            def metadataClient = new OrkesMetadataClient()
+            metadataClient.setRootURI("http://localhost:${port}/api/")
+
+            stubFor get("/api/metadata/taskdefs/task0")
+                    .willReturn(ok()
+                            .withHeader("Content-Type", "application/json")
+                            .withBody(json([:])))
+        when:
+            metadataClient.getTaskDef("task0")
+
+        then:
+            verify(0, postRequestedFor(urlEqualTo("/api/token")))
+            verify(1, getRequestedFor(urlEqualTo("/api/metadata/taskdefs/task0")))
+    }
+
+    def "it should generate a token before a request if credentials are set"() {
+        given:
+            def metadataClient = new OrkesMetadataClient()
+            metadataClient.setRootURI("http://localhost:${port}/api/")
+            metadataClient.withCredentials(keyId, secret)
+
+            stubFor post("/api/token")
+                    .withRequestBody(equalToJson(json(keyId: keyId, keySecret: secret)))
+                    .willReturn(ok()
+                            .withHeader("Content-Type", "application/json")
+                            .withBody(json(token: "TEST_TOKEN")))
+
+            stubFor get("/api/metadata/taskdefs/task0")
+                    .withHeader("X-Authorization", equalTo("TEST_TOKEN"))
+                    .willReturn(ok()
+                            .withHeader("Content-Type", "application/json")
+                            .withBody(json([:])))
+        when:
+            metadataClient.getTaskDef("task0")
+
+        then:
+            verify(1, postRequestedFor(urlEqualTo("/api/token")))
+            verify(1, getRequestedFor(urlEqualTo("/api/metadata/taskdefs/task0")))
+    }
+
+
+    def "it should generate token only once"() {
+        given:
+            def metadataClient = new OrkesMetadataClient()
+            metadataClient.setRootURI("http://localhost:${port}/api/")
+            metadataClient.withCredentials(keyId, secret)
+
+            stubFor post("/api/token")
+                    .withRequestBody(equalToJson(json(keyId: keyId, keySecret: secret)))
+                    .willReturn(ok()
+                            .withHeader("Content-Type", "application/json")
+                            .withBody(json(token: "TEST_TOKEN")))
+
+            stubFor get("/api/metadata/taskdefs/task0")
+                    .withHeader("X-Authorization", equalTo("TEST_TOKEN"))
+                    .willReturn(ok()
+                            .withHeader("Content-Type", "application/json")
+                            .withBody(json([:])))
+
+        when:
+            def threads = 10
+            def latch = new CountDownLatch(threads)
+            threads.times {
+                Thread.start {
+                    latch.countDown()
+                    metadataClient.getTaskDef("task0")
+                }
+            }
+
+        then:
+            await().atMost(5, SECONDS).until {
+                verify(1, postRequestedFor(urlEqualTo("/api/token")))
+                verify(threads, getRequestedFor(urlEqualTo("/api/metadata/taskdefs/task0")))
+                true
+            }
+    }
+}


### PR DESCRIPTION
- `TokenHolder` is now an instance variable.
- This allows creating clients that talk to different conductor instances within the same Java application.
- Added Spock and Wiremock for testing.

---

My assumption was that one credential per application (Java process) would be OK. Once a token was generated it was shared by all clients. That's why it was static. In hindsight it's clear that this is a limitation.

Every client instance before making a request will now generate its own token.