### PR TITLE
Fix number deserialization

### DIFF
--- a/src/main/java/io/orkes/conductor/client/ApiClient.java
+++ b/src/main/java/io/orkes/conductor/client/ApiClient.java
@@ -56,7 +56,6 @@ import io.orkes.conductor.client.model.GenerateTokenRequest;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import com.google.gson.GsonBuilder;
 import com.squareup.okhttp.*;
 import com.squareup.okhttp.internal.http.HttpMethod;
 import okio.BufferedSink;
@@ -113,9 +112,7 @@ public class ApiClient {
         httpClient.setRetryOnConnectionFailure(true);
         verifyingSsl = true;
         json = new JSON();
-        GsonBuilder builder = new GsonBuilder().serializeNulls();
-        json.setGson(builder.create());
-        authentications = new HashMap<String, Authentication>();
+        authentications = new HashMap<>();
     }
 
     public ApiClient(

--- a/src/main/java/io/orkes/conductor/client/http/JSON.java
+++ b/src/main/java/io/orkes/conductor/client/http/JSON.java
@@ -67,7 +67,6 @@ public class JSON {
     public JSON() {
         gson = createGson()
                 .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
-                .setNumberToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
                 .registerTypeAdapter(Date.class, dateTypeAdapter)
                 .registerTypeAdapter(java.sql.Date.class, sqlDateTypeAdapter)
                 .registerTypeAdapter(OffsetDateTime.class, offsetDateTimeTypeAdapter)

--- a/src/main/java/io/orkes/conductor/client/http/JSON.java
+++ b/src/main/java/io/orkes/conductor/client/http/JSON.java
@@ -65,13 +65,15 @@ public class JSON {
     }
 
     public JSON() {
-        gson =
-                createGson()
-                        .registerTypeAdapter(Date.class, dateTypeAdapter)
-                        .registerTypeAdapter(java.sql.Date.class, sqlDateTypeAdapter)
-                        .registerTypeAdapter(OffsetDateTime.class, offsetDateTimeTypeAdapter)
-                        .registerTypeAdapter(LocalDate.class, localDateTypeAdapter)
-                        .create();
+        gson = createGson()
+                .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+                .setNumberToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+                .registerTypeAdapter(Date.class, dateTypeAdapter)
+                .registerTypeAdapter(java.sql.Date.class, sqlDateTypeAdapter)
+                .registerTypeAdapter(OffsetDateTime.class, offsetDateTimeTypeAdapter)
+                .registerTypeAdapter(LocalDate.class, localDateTypeAdapter)
+                .serializeNulls()
+                .create();
     }
 
     /**

--- a/src/main/java/io/orkes/conductor/client/http/JSON.java
+++ b/src/main/java/io/orkes/conductor/client/http/JSON.java
@@ -32,7 +32,7 @@ import com.google.gson.stream.JsonWriter;
 import io.gsonfire.GsonFireBuilder;
 
 public class JSON {
-    private Gson gson;
+    private final Gson gson;
     private boolean isLenientOnJson = false;
     private DateTypeAdapter dateTypeAdapter = new DateTypeAdapter();
     private SqlDateTypeAdapter sqlDateTypeAdapter = new SqlDateTypeAdapter();
@@ -74,26 +74,6 @@ public class JSON {
                 .registerTypeAdapter(LocalDate.class, localDateTypeAdapter)
                 .serializeNulls()
                 .create();
-    }
-
-    /**
-     * Get Gson.
-     *
-     * @return Gson
-     */
-    public Gson getGson() {
-        return gson;
-    }
-
-    /**
-     * Set Gson.
-     *
-     * @param gson Gson
-     * @return JSON
-     */
-    public JSON setGson(Gson gson) {
-        this.gson = gson;
-        return this;
     }
 
     public JSON setLenientOnJson(boolean lenientOnJson) {


### PR DESCRIPTION
## Changes 
- Set default number strategy to `LONG_OR_DOUBLE`. (Or should we make this configurable. How? @v1r3n, @gardusig )
- Avoid unnecessary creation of `Gson` instance.

## NOTES
Gson's default behaviour is to deserialize as `Double`. Deserializing as a floating point number may cause loss of precision. That's why we want to switch to `LONG_OR_DOUBLE` strategy.

![image](https://user-images.githubusercontent.com/4755315/200395138-de64f941-b857-428a-8afe-644e23cbcee4.png)
