### PR TITLE
NOTASK - fix e2e correct workflow search test use correct app id

### DIFF
--- a/src/test/java/io/orkes/conductor/client/e2e/WorkflowSearchTests.java
+++ b/src/test/java/io/orkes/conductor/client/e2e/WorkflowSearchTests.java
@@ -143,12 +143,12 @@ public class WorkflowSearchTests {
         });
 
         authorizationRequest = new AuthorizationRequest();
-        authorizationRequest.setSubject(new SubjectRef().id(getEnv(ApiUtil.USER2_APP_ID)).type(SubjectRef.TypeEnum.USER));
+        authorizationRequest.setSubject(new SubjectRef().id("app:"+ getEnv(ApiUtil.USER2_APP_ID)).type(SubjectRef.TypeEnum.USER));
         authorizationRequest.setAccess(List.of(AuthorizationRequest.AccessEnum.READ));
         authorizationRequest.setTarget(new TargetRef().id("department:" + department).type(TargetRef.TypeEnum.TAG));
         authorizationClient.grantPermissions(authorizationRequest);
         authorizationRequest = new AuthorizationRequest();
-        authorizationRequest.setSubject(new SubjectRef().id(getEnv(ApiUtil.USER2_APP_ID)).type(SubjectRef.TypeEnum.USER));
+        authorizationRequest.setSubject(new SubjectRef().id("app:"+ getEnv(ApiUtil.USER2_APP_ID)).type(SubjectRef.TypeEnum.USER));
         authorizationRequest.setAccess(List.of(AuthorizationRequest.AccessEnum.READ));
         authorizationRequest.setTarget(new TargetRef().id("department2:" + department).type(TargetRef.TypeEnum.TAG));
         authorizationClient.grantPermissions(authorizationRequest);


### PR DESCRIPTION
> most likely what happened was:
I was writing a duplicate search bug test, and then did this
`authorizationRequest.setSubject(new SubjectRef().id(getEnv(ApiUtil.USER2_APP_ID)).type(SubjectRef.TypeEnum.USER));`
and then granted access to that Id, which did not have app , thought we had a bug, created PR with a fix
so writing a wrong test caused this

<img width="514" alt="image" src="https://user-images.githubusercontent.com/13348474/235741778-ed30aac1-b328-4446-9aaf-8bcf07a8183a.png">
(post-change https://github.com/orkes-io/orkes-conductor/pull/1130)